### PR TITLE
Kcloud에서 환경변수가 덮어쓰이는 문제 해결

### DIFF
--- a/dockerize/Dockerfile
+++ b/dockerize/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "export PATH=/dafny:\$PATH" >> /home/student/.bashrc
 
 # Install huggingface
 RUN pip3 install -U "huggingface_hub[cli]"
-RUN echo "export PATH=$HOME/.local/bin:$PATH" >> /home/student/.bashrc
+RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> /home/student/.bashrc
 
 # Setup BitNet
 RUN git clone --recursive https://github.com/prosyslab-classroom/BitNet

--- a/dockerize/Dockerfile
+++ b/dockerize/Dockerfile
@@ -37,7 +37,7 @@ RUN $SCRIPT/install-ocaml.sh
 # Setup checkml
 WORKDIR /
 USER root
-RUN git clone https://github.com/prosyslab-classroom/checkml.git 
+RUN git clone https://github.com/prosyslab-classroom/checkml.git
 RUN cd checkml && ./build.sh
 RUN cp /checkml/_build/default/src/checkml.exe /usr/bin/checkml
 
@@ -50,7 +50,7 @@ RUN echo "export PATH=/dafny:\$PATH" >> /home/student/.bashrc
 
 # Install huggingface
 RUN pip3 install -U "huggingface_hub[cli]"
-RUN echo "export PATH=\"$HOME/.local/bin:$PATH\"" >> /home/student/.bashrc
+RUN echo "export PATH=$HOME/.local/bin:$PATH" >> /home/student/.bashrc
 
 # Setup BitNet
 RUN git clone --recursive https://github.com/prosyslab-classroom/BitNet


### PR DESCRIPTION
huggingface 설정 스크립트에서 환경변수를 설정할 때 도커 빌드 타이밍의 환경변수가 덮어쓰이는 것 같습니다.
그래서 새 쉘에 로그인할 때마가 `eval $(opam env)`를 새로 실행해야 하는 문제가 있습니다.
따라서 빌드 타임에 PATH 환경변수를 가져와 덮어씌우지 않도록 수정했습니다.